### PR TITLE
Add shortcut for lockscreen

### DIFF
--- a/xdg/globalkeyshortcuts.conf
+++ b/xdg/globalkeyshortcuts.conf
@@ -39,3 +39,8 @@ Exec=xdg-open, about:blank
 Comment=screen shot
 Enabled=true
 Exec=lximage-qt, -s
+
+[Control%2BAlt%2BL.30]
+Comment=lockscreen
+Enabled=true
+Exec=xdg-screensaver, lock


### PR DESCRIPTION
Let's add a default shortcut to call xdg-screensaver and lock the
screen.
Proposing: Ctrl+Alt+l in relation to Ctrl+Alt+d