### PR TITLE
Don't use automatic string conversions

### DIFF
--- a/client/CMakeLists.txt
+++ b/client/CMakeLists.txt
@@ -173,7 +173,13 @@ target_include_directories(${PROJECT_NAME}
 )
 
 target_compile_definitions(${PROJECT_NAME}
-    PRIVATE "SHARED_EXPORT=Q_DECL_EXPORT"
+    PRIVATE
+        "SHARED_EXPORT=Q_DECL_EXPORT"
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
 )
 
 export(TARGETS ${PROJECT_NAME} FILE "${CMAKE_BINARY_DIR}/${PROJECT_NAME}-targets.cmake")

--- a/client/client.cpp
+++ b/client/client.cpp
@@ -39,12 +39,12 @@ namespace GlobalKeyShortcut
 ClientImpl::ClientImpl(Client *interface, QObject *parent)
     : QObject(parent)
     , mInterface(interface)
-    , mServiceWatcher(new QDBusServiceWatcher("org.lxqt.global_key_shortcuts", QDBusConnection::sessionBus(), QDBusServiceWatcher::WatchForOwnerChange, this))
+    , mServiceWatcher(new QDBusServiceWatcher(QLatin1String("org.lxqt.global_key_shortcuts"), QDBusConnection::sessionBus(), QDBusServiceWatcher::WatchForOwnerChange, this))
     , mDaemonPresent(false)
 {
     connect(mServiceWatcher, SIGNAL(serviceUnregistered(QString)), this, SLOT(daemonDisappeared(QString)));
     connect(mServiceWatcher, SIGNAL(serviceRegistered(QString)), this, SLOT(daemonAppeared(QString)));
-    mProxy = new org::lxqt::global_key_shortcuts::native("org.lxqt.global_key_shortcuts", "/native", QDBusConnection::sessionBus(), this);
+    mProxy = new org::lxqt::global_key_shortcuts::native(QLatin1String("org.lxqt.global_key_shortcuts"), QStringLiteral("/native"), QDBusConnection::sessionBus(), this);
     mDaemonPresent = mProxy->isValid();
 
     connect(this, SIGNAL(emitShortcutGrabbed(QString)), mInterface, SIGNAL(shortcutGrabbed(QString)));
@@ -61,7 +61,7 @@ ClientImpl::~ClientImpl()
     QMap<QString, Action*>::iterator M = mActions.end();
     for (QMap<QString, Action*>::iterator I = mActions.begin(); I != M; ++I)
     {
-        QDBusConnection::sessionBus().unregisterObject(QString("/global_key_shortcuts") + I.key());
+        QDBusConnection::sessionBus().unregisterObject(QLatin1String("/global_key_shortcuts") + I.key());
 
         delete I.value();
     }
@@ -123,7 +123,7 @@ void ClientImpl::registrationFinished(QDBusPendingCallWatcher *watcher)
 
 Action *ClientImpl::addClientAction(const QString &shortcut, const QString &path, const QString &description, QObject *parent)
 {
-    if (!QRegExp("(/[A-Za-z0-9_]+){2,}").exactMatch(path))
+    if (!QRegExp(QStringLiteral("(/[A-Za-z0-9_]+){2,}")).exactMatch(path))
     {
         return 0;
     }
@@ -138,7 +138,7 @@ Action *ClientImpl::addClientAction(const QString &shortcut, const QString &path
     ActionImpl *globalActionImpl = new ActionImpl(this, globalAction, path, description, globalAction);
     globalAction->impl = globalActionImpl;
 
-    if (!QDBusConnection::sessionBus().registerObject(QString("/global_key_shortcuts") + path, globalActionImpl))
+    if (!QDBusConnection::sessionBus().registerObject(QLatin1String("/global_key_shortcuts") + path, globalActionImpl))
     {
         return 0;
     }
@@ -212,7 +212,7 @@ bool ClientImpl::removeClientAction(const QString &path)
         return false;
     }
 
-    QDBusConnection::sessionBus().unregisterObject(QString("/global_key_shortcuts") + path);
+    QDBusConnection::sessionBus().unregisterObject(QLatin1String("/global_key_shortcuts") + path);
 
     mActions[path]->disconnect();
     mActions.remove(path);
@@ -246,7 +246,7 @@ void ClientImpl::removeAction(ActionImpl *actionImpl)
     QDBusPendingReply<bool> reply = mProxy->deactivateClientAction(QDBusObjectPath(path));
     reply.waitForFinished();
 
-    QDBusConnection::sessionBus().unregisterObject(QString("/global_key_shortcuts") + path);
+    QDBusConnection::sessionBus().unregisterObject(QLatin1String("/global_key_shortcuts") + path);
 
     mActions[path]->disconnect();
     mActions.remove(path);

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -139,6 +139,14 @@ set(${PROJECT_NAME}_ALL_FILES
 )
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_ALL_FILES})
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
+)
 target_link_libraries(${PROJECT_NAME} KF5::WindowSystem lxqt)
 
 install(TARGETS

--- a/config/actions.cpp
+++ b/config/actions.cpp
@@ -31,12 +31,12 @@
 
 Actions::Actions(QObject *parent)
     : QObject(parent)
-    , mServiceWatcher(new QDBusServiceWatcher("org.lxqt.global_key_shortcuts", QDBusConnection::sessionBus(), QDBusServiceWatcher::WatchForOwnerChange, this))
+    , mServiceWatcher(new QDBusServiceWatcher(QLatin1String("org.lxqt.global_key_shortcuts"), QDBusConnection::sessionBus(), QDBusServiceWatcher::WatchForOwnerChange, this))
     , mMultipleActionsBehaviour(MULTIPLE_ACTIONS_BEHAVIOUR_FIRST)
 {
     connect(mServiceWatcher, SIGNAL(serviceUnregistered(QString)), this, SLOT(on_daemonDisappeared(QString)));
     connect(mServiceWatcher, SIGNAL(serviceRegistered(QString)), this, SLOT(on_daemonAppeared(QString)));
-    mDaemonProxy = new org::lxqt::global_key_shortcuts::daemon("org.lxqt.global_key_shortcuts", "/daemon", QDBusConnection::sessionBus(), this);
+    mDaemonProxy = new org::lxqt::global_key_shortcuts::daemon(QLatin1String("org.lxqt.global_key_shortcuts"), QStringLiteral("/daemon"), QDBusConnection::sessionBus(), this);
 
     connect(mDaemonProxy, SIGNAL(actionAdded(qulonglong)), this, SLOT(on_actionAdded(qulonglong)));
     connect(mDaemonProxy, SIGNAL(actionEnabled(qulonglong, bool)), this, SLOT(on_actionEnabled(qulonglong, bool)));
@@ -82,7 +82,7 @@ void Actions::init()
     GeneralActionInfos::const_iterator M = mGeneralActionInfo.constEnd();
     for (GeneralActionInfos::const_iterator I = mGeneralActionInfo.constBegin(); I != M; ++I)
     {
-        if (I.value().type == "client")
+        if (I.value().type == QLatin1String("client"))
         {
             QString shortcut;
             QString description;
@@ -100,7 +100,7 @@ void Actions::init()
                 updateClientActionSender(I.key());
             }
         }
-        else if (I.value().type == "method")
+        else if (I.value().type == QLatin1String("method"))
         {
             QString shortcut;
             QString description;
@@ -122,7 +122,7 @@ void Actions::init()
                 mMethodActionInfo[I.key()] = info;
             }
         }
-        else if (I.value().type == "command")
+        else if (I.value().type == QLatin1String("command"))
         {
             QString shortcut;
             QString description;
@@ -237,7 +237,7 @@ void Actions::do_actionAdded(qulonglong id)
         mGeneralActionInfo[id] = generalActionInfo;
     }
 
-    if (type == "client")
+    if (type == QLatin1String("client"))
     {
         QDBusObjectPath path;
         if (getClientActionInfoById(id, shortcut, description, enabled, path))
@@ -250,7 +250,7 @@ void Actions::do_actionAdded(qulonglong id)
             mClientActionInfo[id] = clientActionInfo;
         }
     }
-    else if (type == "method")
+    else if (type == QLatin1String("method"))
     {
         QString service;
         QDBusObjectPath path;
@@ -269,7 +269,7 @@ void Actions::do_actionAdded(qulonglong id)
             mMethodActionInfo[id] = methodActionInfo;
         }
     }
-    else if (type == "command")
+    else if (type == QLatin1String("command"))
     {
         QString command;
         QStringList arguments;
@@ -299,7 +299,7 @@ void Actions::on_actionEnabled(qulonglong id, bool enabled)
     {
         GI.value().enabled = enabled;
 
-        if (GI.value().type == "client")
+        if (GI.value().type == QLatin1String("client"))
         {
             ClientActionInfos::iterator DI = mClientActionInfo.find(id);
             if (DI != mClientActionInfo.end())
@@ -307,7 +307,7 @@ void Actions::on_actionEnabled(qulonglong id, bool enabled)
                 DI.value().enabled = enabled;
             }
         }
-        else if (GI.value().type == "method")
+        else if (GI.value().type == QLatin1String("method"))
         {
             MethodActionInfos::iterator MI = mMethodActionInfo.find(id);
             if (MI != mMethodActionInfo.end())
@@ -315,7 +315,7 @@ void Actions::on_actionEnabled(qulonglong id, bool enabled)
                 MI.value().enabled = enabled;
             }
         }
-        else if (GI.value().type == "command")
+        else if (GI.value().type == QLatin1String("command"))
         {
             CommandActionInfos::iterator CI = mCommandActionInfo.find(id);
             if (CI != mCommandActionInfo.end())
@@ -355,7 +355,7 @@ void Actions::on_actionsSwapped(qulonglong id1, qulonglong id2)
 
         if (GI1.value().type == GI2.value().type)
         {
-            if (GI1.value().type == "client")
+            if (GI1.value().type == QLatin1String("client"))
             {
                 ClientActionInfos::iterator DI1 = mClientActionInfo.find(id1);
                 ClientActionInfos::iterator DI2 = mClientActionInfo.find(id2);
@@ -367,7 +367,7 @@ void Actions::on_actionsSwapped(qulonglong id1, qulonglong id2)
                     swapped = true;
                 }
             }
-            else if (GI1.value().type == "method")
+            else if (GI1.value().type == QLatin1String("method"))
             {
                 MethodActionInfos::iterator MI1 = mMethodActionInfo.find(id1);
                 MethodActionInfos::iterator MI2 = mMethodActionInfo.find(id2);
@@ -379,7 +379,7 @@ void Actions::on_actionsSwapped(qulonglong id1, qulonglong id2)
                     swapped = true;
                 }
             }
-            else if (GI1.value().type == "command")
+            else if (GI1.value().type == QLatin1String("command"))
             {
                 CommandActionInfos::iterator CI1 = mCommandActionInfo.find(id1);
                 CommandActionInfos::iterator CI2 = mCommandActionInfo.find(id2);

--- a/config/default_model.cpp
+++ b/config/default_model.cpp
@@ -46,9 +46,9 @@ DefaultModel::DefaultModel(Actions *actions, const QColor &grayedOutColour, cons
     connect(actions, SIGNAL(actionsSwapped(qulonglong, qulonglong)), SLOT(actionsSwapped(qulonglong, qulonglong)));
     connect(actions, SIGNAL(actionRemoved(qulonglong)), SLOT(actionRemoved(qulonglong)));
 
-    mVerboseType["command"] = tr("Command");
-    mVerboseType["method"] = tr("DBus call");
-    mVerboseType["client"] = tr("Client");
+    mVerboseType[QStringLiteral("command")] = tr("Command");
+    mVerboseType[QStringLiteral("method")] = tr("DBus call");
+    mVerboseType[QLatin1String("client")] = tr("Client");
 }
 
 DefaultModel::~DefaultModel()
@@ -99,7 +99,7 @@ QVariant DefaultModel::data(const QModelIndex &index, int role) const
         {
             qulonglong id = mContent.keys()[index.row()];
             bool multiple = (index.column() == 1) && (mShortcuts[mContent[id].shortcut].size() > 1);
-            bool inactive = (mContent[id].type == "client") && (mActions->getClientActionSender(id).isEmpty());
+            bool inactive = (mContent[id].type == QLatin1String("client")) && (mActions->getClientActionSender(id).isEmpty());
             if (multiple || inactive)
                 return multiple ? (inactive ? mHighlightedItalicFont : mHighlightedFont) : mItalicFont;
         }

--- a/config/edit_action_dialog.cpp
+++ b/config/edit_action_dialog.cpp
@@ -58,24 +58,24 @@ static QString joinCommandLine(const QString &command, QStringList arguments)
     for (int i = 0; i < m; ++i)
     {
         QString &item = arguments[i];
-        if (item.contains(QRegExp("[ \r\n\t\"']")))
+        if (item.contains(QRegExp(QStringLiteral("[ \r\n\t\"']"))))
         {
-            item.prepend("'").append("'");
+            item.prepend(QLatin1Char('\'')).append(QLatin1Char('\''));
         }
         else if (item.isEmpty())
         {
-            item = QString("''");
+            item = QString::fromLatin1("''");
         }
     }
-    return arguments.join(" ");
+    return arguments.join(QLatin1Char(' '));
 }
 
 static QStringList splitCommandLine(QString commandLine)
 {
-    commandLine.prepend(" ").append(" ");
+    commandLine.prepend(QLatin1Char(' ')).append(QLatin1Char(' '));
     QStringList result;
-    QRegExp spacePattern("\\s+");
-    QRegExp itemPattern("([^ \r\n\t\"']+)|((\"([^\"]|\\\")*\")|('([^']|\\')*'))(?=\\s)");
+    QRegExp spacePattern(QStringLiteral("\\s+"));
+    QRegExp itemPattern(QStringLiteral("([^ \r\n\t\"']+)|((\"([^\"]|\\\")*\")|('([^']|\\')*'))(?=\\s)"));
 
     for (int pos = 0; ;)
     {
@@ -164,16 +164,16 @@ bool EditActionDialog::load(qulonglong id)
             return false;
         }
 
-        bool canEdit = ((info.second.type == "command") || (info.second.type == "method"));
+        bool canEdit = ((info.second.type == QLatin1String("command")) || (info.second.type == QLatin1String("method")));
 
         mShortcut = info.second.shortcut;
         shortcut_SS->setText(mShortcut);
         description_LE->setText(info.second.description);
         enabled_CB->setChecked(info.second.enabled);
-        command_RB->setChecked(info.second.type == "command");
-        dbus_method_RB->setChecked(info.second.type == "method");
-        action_SW->setCurrentWidget((info.second.type == "method") ? dbus_method_P : command_P);
-        if (info.second.type == "command")
+        command_RB->setChecked(info.second.type == QLatin1String("command"));
+        dbus_method_RB->setChecked(info.second.type == QLatin1String("method"));
+        action_SW->setCurrentWidget((info.second.type == QLatin1String("method")) ? dbus_method_P : command_P);
+        if (info.second.type == QLatin1String("command"))
         {
             QPair<bool, CommandActionInfo> commandInfo = mActions->commandActionInfoById(id);
             if (!commandInfo.first)
@@ -182,7 +182,7 @@ bool EditActionDialog::load(qulonglong id)
             }
             command_PTE->setPlainText(joinCommandLine(commandInfo.second.command, commandInfo.second.arguments));
         }
-        else if (info.second.type == "method")
+        else if (info.second.type == QLatin1String("method"))
         {
             QPair<bool, MethodActionInfo> methodInfo = mActions->methodActionInfoById(id);
             if (!methodInfo.first)

--- a/daemon/CMakeLists.txt
+++ b/daemon/CMakeLists.txt
@@ -147,6 +147,14 @@ set_property(SOURCE
 )
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_ALL_FILES})
+target_compile_definitions(${PROJECT_NAME}
+    PRIVATE
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
+)
 target_link_libraries(${PROJECT_NAME} ${X11_LIBRARIES} lxqt Qt5::Widgets Qt5::DBus)
 lxqt_enable_target_exceptions(${PROJECT_NAME} PRIVATE)
 

--- a/daemon/client_action.cpp
+++ b/daemon/client_action.cpp
@@ -75,7 +75,7 @@ void ClientAction::appeared(const QDBusConnection &connection, const QString &se
         return;
     }
     mService = service;
-    mProxy = new ClientProxy(mService, QDBusObjectPath("/global_key_shortcuts" + mPath.path()), connection);
+    mProxy = new ClientProxy(mService, QDBusObjectPath(QStringLiteral("/global_key_shortcuts") + mPath.path()), connection);
 }
 
 void ClientAction::disappeared()

--- a/daemon/command_action.cpp
+++ b/daemon/command_action.cpp
@@ -53,7 +53,7 @@ bool CommandAction::call()
     bool result = QProcess::startDetached(mCommand, mArgs);
     if (!result)
     {
-        mLogTarget->log(LOG_WARNING, "Failed to launch command \"%s\"%s", qPrintable(mCommand), qPrintable(joinToString(mArgs, " \"", "\" \"", "\"")));
+        mLogTarget->log(LOG_WARNING, "Failed to launch command \"%s\"%s", qPrintable(mCommand), qPrintable(joinToString(mArgs, QStringLiteral(" \""), QStringLiteral("\" \""), QStringLiteral("\""))));
     }
 
     return result;

--- a/daemon/core.cpp
+++ b/daemon/core.cpp
@@ -411,7 +411,7 @@ Core::Core(bool useSyslog, bool minLogLevelSet, int minLogLevel, const QStringLi
     initBothPipeEnds(mX11RequestPipe);
     initBothPipeEnds(mX11ResponsePipe);
 
-    mConfigFile = QString(getenv("HOME")) + QStringLiteral("/.config/global_key_shortcutss.ini");
+    mConfigFile = QFile::decodeName(qgetenv("HOME")) + QStringLiteral("/.config/global_key_shortcutss.ini");
 
     try
     {
@@ -423,7 +423,7 @@ Core::Core(bool useSyslog, bool minLogLevelSet, int minLogLevel, const QStringLi
         lxqtApp->listenToUnixSignals(QList<int>() << SIGTERM << SIGINT);
 
 
-        if (!QDBusConnection::sessionBus().registerService("org.lxqt.global_key_shortcuts"))
+        if (!QDBusConnection::sessionBus().registerService(QStringLiteral("org.lxqt.global_key_shortcuts")))
         {
             throw std::runtime_error(std::string("Cannot register service 'org.lxqt.global_key_shortcuts'"));
         }
@@ -737,36 +737,36 @@ void Core::saveConfig()
     switch (mMultipleActionsBehaviour)
     {
     case MULTIPLE_ACTIONS_BEHAVIOUR_FIRST:
-        settings.setValue(/* General/ */"MultipleActionsBehaviour", firstStr);
+        settings.setValue(/* General/ */QLatin1String("MultipleActionsBehaviour"), firstStr);
         break;
 
     case MULTIPLE_ACTIONS_BEHAVIOUR_LAST:
-        settings.setValue(/* General/ */"MultipleActionsBehaviour", lastStr);
+        settings.setValue(/* General/ */QLatin1String("MultipleActionsBehaviour"), lastStr);
         break;
 
     case MULTIPLE_ACTIONS_BEHAVIOUR_ALL:
-        settings.setValue(/* General/ */"MultipleActionsBehaviour", allStr);
+        settings.setValue(/* General/ */QLatin1String("MultipleActionsBehaviour"), allStr);
         break;
 
     case MULTIPLE_ACTIONS_BEHAVIOUR_NONE:
-        settings.setValue(/* General/ */"MultipleActionsBehaviour", noneStr);
+        settings.setValue(/* General/ */QLatin1String("MultipleActionsBehaviour"), noneStr);
         break;
 
     default:
         ;
     }
 
-    settings.setValue(/* General/ */"AllowGrabLocks",       mAllowGrabLocks);
-    settings.setValue(/* General/ */"AllowGrabBaseSpecial", mAllowGrabBaseSpecial);
-    settings.setValue(/* General/ */"AllowGrabMiscSpecial", mAllowGrabMiscSpecial);
-    settings.setValue(/* General/ */"AllowGrabBaseKeypad",  mAllowGrabBaseKeypad);
-    settings.setValue(/* General/ */"AllowGrabMiscKeypad",  mAllowGrabMiscKeypad);
+    settings.setValue(/* General/ */QLatin1String("AllowGrabLocks"),       mAllowGrabLocks);
+    settings.setValue(/* General/ */QLatin1String("AllowGrabBaseSpecial"), mAllowGrabBaseSpecial);
+    settings.setValue(/* General/ */QLatin1String("AllowGrabMiscSpecial"), mAllowGrabMiscSpecial);
+    settings.setValue(/* General/ */QLatin1String("AllowGrabBaseKeypad"),  mAllowGrabBaseKeypad);
+    settings.setValue(/* General/ */QLatin1String("AllowGrabMiscKeypad"),  mAllowGrabMiscKeypad);
 
     ShortcutAndActionById::const_iterator lastShortcutAndActionById = mShortcutAndActionById.constEnd();
     for (ShortcutAndActionById::const_iterator shortcutAndActionById = mShortcutAndActionById.constBegin(); shortcutAndActionById != lastShortcutAndActionById; ++shortcutAndActionById)
     {
         const BaseAction *action = shortcutAndActionById.value().second;
-        QString section = shortcutAndActionById.value().first + "." + QString::number(shortcutAndActionById.key());
+        QString section = shortcutAndActionById.value().first + QLatin1Char('.') + QString::number(shortcutAndActionById.key());
 
         settings.beginGroup(section);
 
@@ -1141,8 +1141,8 @@ void Core::run()
         allModifiers.insert(ignoreLocks);
     }
 
-    const QString metaLeft = XKeysymToString(XK_Super_L);
-    const QString metaRight = XKeysymToString(XK_Super_R);
+    const QString metaLeft = QString::fromUtf8(XKeysymToString(XK_Super_L));
+    const QString metaRight = QString::fromUtf8(XKeysymToString(XK_Super_R));
 
     char signal = 0;
     if (write(mX11ResponsePipe[STDOUT_FILENO], &signal, sizeof(signal)) == sizeof(signal))
@@ -1227,7 +1227,7 @@ void Core::run()
 
                                             if ((event.xkey.state & allShifts) == MetaMask)
                                             {
-                                                shortcut = XKeysymToString(keySym);
+                                                shortcut = QString::fromUtf8(XKeysymToString(keySym));
                                                 event.xkey.state &= ~allShifts; // Modifier keys must not use shift states.
                                             }
                                             else
@@ -1248,30 +1248,30 @@ void Core::run()
                                         {
                                             if (event.xkey.state & ShiftMask)
                                             {
-                                                shortcut += "Shift+";
+                                                shortcut += QLatin1String("Shift+");
                                             }
                                             if (event.xkey.state & ControlMask)
                                             {
-                                                shortcut += "Control+";
+                                                shortcut += QLatin1String("Control+");
                                             }
                                             if (event.xkey.state & AltMask)
                                             {
-                                                shortcut += "Alt+";
+                                                shortcut += QLatin1String("Alt+");
                                             }
                                             if (event.xkey.state & MetaMask)
                                             {
-                                                shortcut += "Meta+";
+                                                shortcut += QLatin1String("Meta+");
                                             }
                                             if (event.xkey.state & Level3Mask)
                                             {
-                                                shortcut += "Level3+";
+                                                shortcut += QLatin1String("Level3+");
                                             }
                                             if (event.xkey.state & Level5Mask)
                                             {
-                                                shortcut += "Level5+";
+                                                shortcut += QLatin1String("Level5+");
                                             }
 
-                                            shortcut += str;
+                                            shortcut += QString::fromUtf8(str);
                                         }
                                     }
                                 }
@@ -1891,7 +1891,7 @@ QString Core::remoteKeycodeToString(KeyCode keyCode)
             qApp->quit();
             return QString();
         }
-        result = str.data();
+        result = QString::fromUtf8(str.data());
     }
 
     return result;
@@ -1995,32 +1995,32 @@ Core::X11Shortcut Core::ShortcutToX11(const QString &shortcut)
 {
     X11Shortcut result(0, 0);
 
-    QStringList parts = shortcut.split('+');
+    QStringList parts = shortcut.split(QLatin1Char('+'));
 
     size_t m = parts.size();
     for (size_t i = 0; i < m - 1; ++i)
     {
-        if (parts[i] == "Shift")
+        if (parts[i] == QLatin1String("Shift"))
         {
             result.second |= ShiftMask;
         }
-        else if (parts[i] == "Control")
+        else if (parts[i] == QLatin1String("Control"))
         {
             result.second |= ControlMask;
         }
-        else if (parts[i] == "Alt")
+        else if (parts[i] == QLatin1String("Alt"))
         {
             result.second |= AltMask;
         }
-        else if (parts[i] == "Meta")
+        else if (parts[i] == QLatin1String("Meta"))
         {
             result.second |= MetaMask;
         }
-        else if (parts[i] == "Level3")
+        else if (parts[i] == QLatin1String("Level3"))
         {
             result.second |= Level3Mask;
         }
-        else if (parts[i] == "Level5")
+        else if (parts[i] == QLatin1String("Level5"))
         {
             result.second |= Level5Mask;
         }
@@ -2049,27 +2049,27 @@ QString Core::X11ToShortcut(const X11Shortcut &X11shortcut)
 
     if (X11shortcut.second & ShiftMask)
     {
-        result += "Shift+";
+        result += QLatin1String("Shift+");
     }
     if (X11shortcut.second & ControlMask)
     {
-        result += "Control+";
+        result += QLatin1String("Control+");
     }
     if (X11shortcut.second & AltMask)
     {
-        result += "Alt+";
+        result += QLatin1String("Alt+");
     }
     if (X11shortcut.second & MetaMask)
     {
-        result += "Meta+";
+        result += QLatin1String("Meta+");
     }
     if (X11shortcut.second & Level3Mask)
     {
-        result += "Level3+";
+        result += QLatin1String("Level3+");
     }
     if (X11shortcut.second & Level5Mask)
     {
-        result += "Level5+";
+        result += QLatin1String("Level5+");
     }
 
     QString key = remoteKeycodeToString(X11shortcut.first);
@@ -2276,7 +2276,7 @@ qulonglong Core::registerMethodAction(const QString &shortcut, const QString &se
 
 void Core::addCommandAction(QPair<QString, qulonglong> &result, const QString &shortcut, const QString &command, const QStringList &arguments, const QString &description)
 {
-    log(LOG_INFO, "addCommandAction shortcut:'%s' command:'%s' arguments:'%s' description:'%s'", qPrintable(shortcut), qPrintable(command), qPrintable(joinToString(arguments, "", "' '", "")), qPrintable(description));
+    log(LOG_INFO, "addCommandAction shortcut:'%s' command:'%s' arguments:'%s' description:'%s'", qPrintable(shortcut), qPrintable(command), qPrintable(joinToString(arguments, QString(), QLatin1String("' '"), QString())), qPrintable(description));
 
     QMutexLocker lock(&mDataMutex);
 
@@ -2418,7 +2418,7 @@ void Core::modifyMethodAction(bool &result, const qulonglong &id, const QString 
 
 void Core::modifyCommandAction(bool &result, const qulonglong &id, const QString &command, const QStringList &arguments, const QString &description)
 {
-    log(LOG_INFO, "modifyCommandAction id:%llu command:'%s' arguments:'%s' description:'%s'", id, qPrintable(command), qPrintable(joinToString(arguments, "", "' '", "")), qPrintable(description));
+    log(LOG_INFO, "modifyCommandAction id:%llu command:'%s' arguments:'%s' description:'%s'", id, qPrintable(command), qPrintable(joinToString(arguments, QString(), QLatin1String("' '"), QString())), qPrintable(description));
 
     QMutexLocker lock(&mDataMutex);
 
@@ -3150,22 +3150,22 @@ GeneralActionInfo Core::actionInfo(const ShortcutAndAction &shortcutAndAction) c
     result.description = action->description();
     result.enabled = action->isEnabled();
 
-    result.type = action->type();
+    result.type = QString::fromLatin1(action->type());
 
-    if (result.type == ClientAction::id())
+    if (result.type == QLatin1String(ClientAction::id()))
     {
         const ClientAction *clientAction = dynamic_cast<const ClientAction *>(action);
         result.info = clientAction->path().path();
     }
-    else if (result.type == MethodAction::id())
+    else if (result.type == QLatin1String(MethodAction::id()))
     {
         const MethodAction *methodAction = dynamic_cast<const MethodAction *>(action);
-        result.info = methodAction->service() + " "
-                      + methodAction->path().path() + " "
-                      + methodAction->interface() + " "
+        result.info = methodAction->service() + QLatin1Char(' ')
+                      + methodAction->path().path() + QLatin1Char(' ')
+                      + methodAction->interface() + QLatin1Char(' ')
                       + methodAction->method();
     }
-    else if (result.type == CommandAction::id())
+    else if (result.type == QLatin1String(CommandAction::id()))
     {
         const CommandAction *commandAction = dynamic_cast<const CommandAction *>(action);
         result.info = joinCommandLine(commandAction->command(), commandAction->args());
@@ -3414,7 +3414,7 @@ void Core::shortcutGrabbed()
                 qApp->quit();
                 return;
             }
-            shortcut = str.data();
+            shortcut = QString::fromUtf8(str.data());
         }
     }
 

--- a/daemon/main.cpp
+++ b/daemon/main.cpp
@@ -237,9 +237,9 @@ int main(int argc, char *argv[])
 
     if (configFiles.empty() && home && *home)
     {
-        if( ! QFile::exists(QString::fromLocal8Bit(home) + "/" DEFAULT_CONFIG) ) //Load default settings
-            configFiles.push_back("/etc/xdg/lxqt/globalkeyshortcuts.conf");
-        configFiles.push_back(QString::fromLocal8Bit(home) + "/" DEFAULT_CONFIG);
+        if( ! QFile::exists(QString::fromLocal8Bit(home) + QLatin1Char('/') + QLatin1String(DEFAULT_CONFIG)) ) //Load default settings
+            configFiles.push_back(QStringLiteral("/etc/xdg/lxqt/globalkeyshortcuts.conf"));
+        configFiles.push_back(QString::fromLocal8Bit(home) + QLatin1Char('/') + QLatin1String(DEFAULT_CONFIG));
     }
 
     LXQt::Application app(argc, argv);

--- a/daemon/string_utils.cpp
+++ b/daemon/string_utils.cpp
@@ -45,14 +45,14 @@ QString joinCommandLine(const QString &command, QStringList arguments)
     for (int i = 0; i < m; ++i)
     {
         QString &item = arguments[i];
-        if (item.contains(QRegExp("[ \r\n\t\"']")))
+        if (item.contains(QRegExp(QStringLiteral("[ \r\n\t\"']"))))
         {
-            item.prepend("'").append("'");
+            item.prepend(QLatin1Char('\'')).append(QLatin1Char('\''));
         }
         else if (item.isEmpty())
         {
-            item = QString("''");
+            item = QString(QStringLiteral("''"));
         }
     }
-    return arguments.join(" ");
+    return arguments.join(QLatin1Char(' '));
 }

--- a/ui/CMakeLists.txt
+++ b/ui/CMakeLists.txt
@@ -148,7 +148,13 @@ target_include_directories(${PROJECT_NAME}
 )
 
 target_compile_definitions(${PROJECT_NAME}
-    PRIVATE "SHARED_EXPORT=Q_DECL_EXPORT"
+    PRIVATE
+        "SHARED_EXPORT=Q_DECL_EXPORT"
+        "QT_USE_QSTRINGBUILDER"
+        "QT_NO_CAST_FROM_ASCII"
+        "QT_NO_CAST_TO_ASCII"
+        "QT_NO_URL_CAST_FROM_STRING"
+        "QT_NO_CAST_FROM_BYTEARRAY"
 )
 
 export(TARGETS ${PROJECT_NAME} APPEND FILE "${CMAKE_BINARY_DIR}/${PROJECT_NAME}-targets.cmake")


### PR DESCRIPTION
* Disables automatic conversions from 8-bit strings (char *) to unicode
  QStrings.
* Disables automatic conversion from QString to 8-bit strings (char *).
* Disables automatic conversions from QByteArray to const char * or const
  void *.
* Disables automatic conversions from QString (or char *) to QUrl.
* Use QStringBuilder for more efficient string creation.

It make us aware of string and encoding conversions.