### PR TITLE
Don't rename a widget or a class without a full refactoring.

### DIFF
--- a/config/main_window.ui
+++ b/config/main_window.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MainWindow</class>
- <widget class="QDialog" name="GlobalKeysConfig">
+ <widget class="QDialog" name="MainWindow">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
Reverted the change. Fixes lxqt/lxqt-globalkeys/issues/107