### PR TITLE
Remember config window size on exiting

### DIFF
--- a/config/main_window.cpp
+++ b/config/main_window.cpp
@@ -32,6 +32,7 @@
 
 #include <QItemSelectionModel>
 #include <QSortFilterProxyModel>
+#include <QSettings>
 
 
 MainWindow::MainWindow(QWidget *parent)
@@ -70,6 +71,18 @@ MainWindow::MainWindow(QWidget *parent)
     connect(mActions, SIGNAL(daemonDisappeared()), SLOT(daemonDisappeared()));
     connect(mActions, SIGNAL(daemonAppeared()), SLOT(daemonAppeared()));
     connect(mActions, SIGNAL(multipleActionsBehaviourChanged(MultipleActionsBehaviour)), SLOT(multipleActionsBehaviourChanged(MultipleActionsBehaviour)));
+
+    // restore/remember win size
+    // FIXME: Change the code structure so that the config file can be obtained from one place.
+    QSettings *config = new QSettings(QStringLiteral("lxqt"), QStringLiteral("globalkeyshortcuts"), this);
+    QSize windowSize = config->value(QStringLiteral("WindowSize"), size()).toSize();
+    if (windowSize.isValid())
+        resize(windowSize);
+    connect(this, &QDialog::finished, [this, config]()
+    {
+        if (config->value(QStringLiteral("WindowSize")) != size())
+            config->setValue(QStringLiteral("WindowSize"), size());
+    });
 }
 
 void MainWindow::changeEvent(QEvent *e)

--- a/config/main_window.ui
+++ b/config/main_window.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>720</width>
-    <height>314</height>
+    <width>750</width>
+    <height>400</height>
    </rect>
   </property>
   <property name="windowTitle">

--- a/daemon/core.cpp
+++ b/daemon/core.cpp
@@ -731,8 +731,9 @@ void Core::saveConfig()
     }
 
     QSettings settings(mConfigFile, QSettings::IniFormat);
-
+    QVariant windowSize = settings.value(QStringLiteral("WindowSize"));
     settings.clear();
+    settings.setValue(QStringLiteral("WindowSize"), windowSize);
 
     switch (mMultipleActionsBehaviour)
     {


### PR DESCRIPTION
NOTE: IMHO, the config file of lxqt-globalkeys is set in weird way by the current code. Qt handles global and user config files automatically. Or I'm missing something here?