### PR TITLE
Fixed loading of settings

### DIFF
--- a/daemon/core.h
+++ b/daemon/core.h
@@ -243,7 +243,6 @@ private:
     bool mAllowGrabMiscKeypad;
     bool mAllowGrabPrintable;
 
-    QScopedPointer<QSettings> mSettings;
     bool mSaveAllowed;
 
     QTimer *mShortcutGrabTimeout;


### PR DESCRIPTION
Fixes https://github.com/lxqt/lxqt-globalkeys/issues/134

Suppose that the user has started the daemon for the first time and then, disabled the shortcut `XY` that comes from a global config file. Now, the user config file includes something like:

```
[XY.9]
Comment=My Shortcut
Enabled=false
Exec=runThis
```

The suffix ".9" depends on when the section is read. On the other hand, a global config file may contain:

```
[XY.1]
Comment=My Shortcut
Enabled=true
Exec=runThis
```

The next time the daemon is started, there's no guarantee that it reads the user section before the global one because `QSettings` sorts sections before returning them (see Qt → qsettings.cpp → QConfFileSettingsPrivate::children). But if it reads `[XY.1]` first, then the value of `Enabled` will be `true`, which means that `false` will be turned into `true` again.

This depends on the contents of all config files, so it's very random.

To prevent it from happening, the patch reads the config files in the order that Qt gives them (XDG hierarchy), so that the user config file always comes first.

As a result, https://github.com/lxqt/lxqt-globalkeys/commit/bd9cb26d217ef7633570c947e5e7e410564eafc1 is reversed, although its purpose is preserved by using `QStandardPaths`.

Also, it's guaranteed that other key-values are read from the user config files because, theoretically, they can be present in global config files too.