### PR TITLE
Better handling of default shortcuts

### DIFF
--- a/config/main_window.h
+++ b/config/main_window.h
@@ -62,6 +62,7 @@ protected slots:
     void on_modify_PB_clicked();
     void on_swap_PB_clicked();
     void on_remove_PB_clicked();
+    void on_default_PB_clicked();
 
     void on_multipleActionsBehaviour_CB_currentIndexChanged(int);
 

--- a/config/main_window.ui
+++ b/config/main_window.ui
@@ -161,6 +161,13 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QPushButton" name="default_PB">
+       <property name="text">
+        <string>Default</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
 (1) Don't bring back removed shortcuts with the next session. Previously, those default shortcuts that were removed by the user were restored with the next daemon startup.

 (2) A Default button is added, which removes all user-defined shortcuts and restores the default ones, by showing a prompt dialog.

Closes https://github.com/lxqt/lxqt-globalkeys/issues/135

@agaida Please be cruel while testing ;)