### PR TITLE
ui: add some translation context for multipleActionsBehaviour values

### DIFF
--- a/config/main_window.ui
+++ b/config/main_window.ui
@@ -123,22 +123,22 @@
       <widget class="QComboBox" name="multipleActionsBehaviour_CB">
        <item>
         <property name="text">
-         <string>First</string>
+         <string comment="globalkeys/config/multipleActions">First</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Last</string>
+         <string comment="globalkeys/config/multipleActions">Last</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>None</string>
+         <string comment="globalkeys/config/multipleActions">None</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>All</string>
+         <string comment="globalkeys/config/multipleActions">All</string>
         </property>
        </item>
       </widget>


### PR DESCRIPTION
Add a "comment" attribute which acts as a translation context.

<hr>

Frankly speaking, I need a separate context here for "None" for Russian translation. Currently it matches the context of the same string from `ScreenGrub`, so I can't translate them differently. I've already tried to achieve this by PR #101, but that way was actually erroneous.

It might be a bit confusing to give a different context to a single string, so I decided to set it for all others string of the same group as well.

Note that another approach to the issue is to rename the whole class `MainWindow` to something different, but that would be something over the top IMHO.
Also it is possible to resolve the issue by tweaking Weblate's settings to prevent forced translation sharing between different components.

PS: sorry I'm a bit oververbose because of such a small problem.