### PR TITLE
Add shortcut to configure display

### DIFF
--- a/xdg/globalkeyshortcuts.conf
+++ b/xdg/globalkeyshortcuts.conf
@@ -40,7 +40,12 @@ Comment=screen shot
 Enabled=true
 Exec=screengrab, -f
 
-[Control%2BAlt%2BL.30]
+[Control%2BAlt%2BL.9]
 Comment=lockscreen
 Enabled=true
 Exec=xdg-screensaver, lock
+
+[XF86Display.10]
+Comment=Launch Monitor
+Enabled=true
+Exec=lxqt-config-monitor


### PR DESCRIPTION
 Launch the lxqt-config-monitor tool when the Display key (XF86Display) key is pressed.