### PR TITLE
Add shortcut to configure display

### DIFF
--- a/xdg/globalkeyshortcuts.conf
+++ b/xdg/globalkeyshortcuts.conf
@@ -44,3 +44,8 @@ Exec=screengrab, -f
 Comment=lockscreen
 Enabled=true
 Exec=xdg-screensaver, lock
+
+[XF86Display.31]
+Comment=Launch Monitor
+Enabled=true
+Exec=lxqt-config-monitor


### PR DESCRIPTION
Launch the lxqt-config-monitor tool when the Display key (XF86Display) key is pressed.