### PR TITLE
Do not grab keys of disabled client actions

### DIFF
--- a/daemon/core.cpp
+++ b/daemon/core.cpp
@@ -2233,7 +2233,7 @@ QPair<QString, qulonglong> Core::addOrRegisterClientAction(const QString &shortc
             mShortcutAndActionById[id].first = newShortcut;
         }
 
-        if (!newShortcut.isEmpty())
+        if (!newShortcut.isEmpty() && shortcutAndAction.second->isEnabled())
         {
             newShortcut = grabOrReuseKey(X11shortcut, newShortcut);
             mIdsByShortcut[newShortcut].insert(id);


### PR DESCRIPTION
When `Core::addOrRegisterClientAction` was called by `Core::addClientAction`, it grabbed keys without checking whether shortcuts were enabled or not and so, it didn't let the same shortcuts be used by apps. A simple check fixes the problem.

Fixes https://github.com/lxqt/lxqt-globalkeys/issues/173