### PR TITLE
Desktop file fix

### DIFF
--- a/config/lxqt-config-globalkeyshortcuts.desktop.in
+++ b/config/lxqt-config-globalkeyshortcuts.desktop.in
@@ -2,7 +2,7 @@
 Type=Application
 Exec=lxqt-config-globalkeyshortcuts
 Icon=preferences-desktop-keyboard
-Categories=Settings;DesktopSettings;Qt;LXQt;
+Categories=Settings;DesktopSettings;Qt;
 OnlyShowIn=LXQt;
 
 #TRANSLATIONS_DIR=translations


### PR DESCRIPTION
desktop-file-validate: "Categories" in group "Desktop Entry" contains an unregistered value "LXQt"