### PR TITLE
Remove KWindowSystem as direct dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,6 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 
-set(KF5_MINIMUM_VERSION "5.36.0")
 set(LXQT_MINIMUM_VERSION "1.3.0")
 set(QT_MINIMUM_VERSION "5.15.0")
 
@@ -23,7 +22,6 @@ set(CMAKE_AUTOUIC ON)
 find_package(Qt5DBus ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5LinguistTools ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5Widgets ${QT_MINIMUM_VERSION} REQUIRED)
-find_package(KF5WindowSystem ${KF5_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt ${LXQT_MINIMUM_VERSION} REQUIRED)
 
 # Version

--- a/config/CMakeLists.txt
+++ b/config/CMakeLists.txt
@@ -134,7 +134,7 @@ set(${PROJECT_NAME}_ALL_FILES
 )
 
 add_executable(${PROJECT_NAME} ${${PROJECT_NAME}_ALL_FILES})
-target_link_libraries(${PROJECT_NAME} KF5::WindowSystem lxqt)
+target_link_libraries(${PROJECT_NAME} lxqt)
 
 install(TARGETS
     ${PROJECT_NAME}


### PR DESCRIPTION
KWindowSystem isn't an source code dependency.
liblxqt brings KWindowSystem in as an INTERFACE_LINK dependency.
