### PR TITLE
Add theme icon to config/main_window.ui

### DIFF
--- a/config/main_window.ui
+++ b/config/main_window.ui
@@ -13,6 +13,9 @@
   <property name="windowTitle">
    <string>Global Actions Manager</string>
   </property>
+  <property name="windowIcon">
+   <iconset theme="preferences-desktop-keyboard"/>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout_2">


### PR DESCRIPTION
Sets the window icon of lxqt-config-globalkeyshortcuts to preferences-desktop-keyboard