### PR TITLE
Do not start under wayland

### DIFF
--- a/daemon/core.cpp
+++ b/daemon/core.cpp
@@ -424,6 +424,10 @@ Core::Core(bool useSyslog, bool minLogLevelSet, int minLogLevel, const QStringLi
             throw std::runtime_error(std::string("Cannot register service 'org.lxqt.global_key_shortcuts'"));
         }
 
+        if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+        {
+            throw std::runtime_error(std::string("Cannot register globalkeys under wayland"));
+        }
 
         if ((c_error = createPipe(mX11ErrorPipe)))
         {


### PR DESCRIPTION
Potential fix for https://github.com/lxqt/lxqt-globalkeys/issues/284

Unfortunately this leads to the annoying popup "module crashed to many times" message now if globalkeys are enabled.

Probably another fix is needed in `lxqt-session` to disable by default the module on wayland.