### PR TITLE
Add icons to dialog buttons

### DIFF
--- a/config/main_window.ui
+++ b/config/main_window.ui
@@ -182,6 +182,10 @@
        <property name="text">
         <string>Default</string>
        </property>
+       <property name="icon">
+        <iconset theme="edit-clear">
+        <normaloff>.</normaloff>.</iconset>
+       </property>
       </widget>
      </item>
      <item>

--- a/config/main_window.ui
+++ b/config/main_window.ui
@@ -202,6 +202,10 @@
        <property name="text">
         <string>Close</string>
        </property>
+       <property name="icon">
+        <iconset theme="window-close">
+        <normaloff>.</normaloff>.</iconset>
+       </property>
       </widget>
      </item>
     </layout>


### PR DESCRIPTION
- Added 'window-close' icon to 'Close'

`lxqt-config-globalkeys` is distinct in that it doesn't use QDialogButtonBox, but instead regular QPushButtons for its dialog buttons. The lack of icons looked odd.

The other dialog button missing an icon is "Default". It should have an icon, but there may be no suitable one.