### PR TITLE
Cleanup default globalkeyshortcuts.conf

### DIFF
--- a/xdg/globalkeyshortcuts.conf
+++ b/xdg/globalkeyshortcuts.conf
@@ -1,4 +1,3 @@
-
 [Control%2BAlt%2BT.1]
 Comment=QTerminal
 Enabled=true
@@ -26,22 +25,22 @@ Exec=lxqt-config-brightness, -i
 
 
 [Control%2BAlt%2BE.6]
-Comment=Pcmanfm
+Comment=PCManFM-Qt
 Enabled=true
 Exec=pcmanfm-qt
 
 [Control%2BAlt%2BI.7]
-Comment=Web browser
+Comment=Web Browser
 Enabled=true
 Exec=xdg-open, about:blank
 
 [Print.8]
-Comment=screen shot
+Comment=Screenshot
 Enabled=true
 Exec=screengrab, -f
 
 [Control%2BAlt%2BL.30]
-Comment=lockscreen
+Comment=Lockscreen
 Enabled=true
 Exec=xdg-screensaver, lock
 


### PR DESCRIPTION
Cleanup `/usr/share/lxqt/globalkeyshortcuts.conf`.
Prior attempt: https://github.com/lxqt/lxqt-globalkeys/pull/272

Note: this does _not_ alter user settings.

##### Steps to reproduce:
1. Rename/move `~/.config/lxqt/globalkeyshortcuts.conf`
2. Restart "Global Keyboard Shorcuts" from Session Settings
3. Launch `lxqt-config-globalkeys`

You should see the default preconfigured shortcuts.