### PR TITLE
Config UI: Enable smooth scrolling for table view

### DIFF
--- a/config/main_window.cpp
+++ b/config/main_window.cpp
@@ -76,6 +76,9 @@ MainWindow::MainWindow(QWidget *parent)
     mSelectionModel = new QItemSelectionModel(actions_TV->model());
     actions_TV->setSelectionModel(mSelectionModel);
 
+    actions_TV->setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    actions_TV->setHorizontalScrollMode(QAbstractItemView::ScrollPerPixel);
+
     connect(filter_LE, &QLineEdit::textChanged, mSortFilterProxyModel, &QSortFilterProxyModel::setFilterFixedString);
 
     connect(mSelectionModel, &QItemSelectionModel::selectionChanged, this, &MainWindow::selectionChanged);


### PR DESCRIPTION
Previously the table view jumped to the next cell when scrolling. IMO smooth scrolling is much more readable.