### PR TITLE
Use single-click instead of double-click for list items' checkboxes

### DIFF
--- a/config/main_window.cpp
+++ b/config/main_window.cpp
@@ -279,15 +279,20 @@ void MainWindow::on_default_PB_clicked()
     QGuiApplication::restoreOverrideCursor();
 }
 
+void MainWindow::on_actions_TV_clicked(const QModelIndex &index)
+{
+    if (index.column() == 0)
+    {
+        qulonglong id = mDefaultModel->id(mSortFilterProxyModel->mapToSource(index));
+        mActions->enableAction(id, !mActions->isActionEnabled(id));
+    }
+}
+
 void MainWindow::on_actions_TV_doubleClicked(const QModelIndex &index)
 {
     switch (index.column())
     {
     case 0:
-    {
-        qulonglong id = mDefaultModel->id(mSortFilterProxyModel->mapToSource(index));
-        mActions->enableAction(id, !mActions->isActionEnabled(id));
-    }
         break;
 
     default:

--- a/config/main_window.h
+++ b/config/main_window.h
@@ -66,6 +66,7 @@ protected slots:
 
     void on_multipleActionsBehaviour_CB_currentIndexChanged(int);
 
+    void on_actions_TV_clicked(const QModelIndex &);
     void on_actions_TV_doubleClicked(const QModelIndex &);
 
 private:


### PR DESCRIPTION
Closes https://github.com/lxqt/lxqt-globalkeys/issues/190

This may not be the best way to handle the checkboxes. I experienced some latency when trying to quickly toggle them.

For all columns != 0, double-click opens the edit dialog as before. For columns == 0, single-click toggles the checkbox.