### PR TITLE
Capitalize 'Id' -> 'ID'

### DIFF
--- a/config/default_model.cpp
+++ b/config/default_model.cpp
@@ -140,7 +140,7 @@ QVariant DefaultModel::headerData(int section, Qt::Orientation orientation, int 
             switch (section)
             {
             case 0:
-                return tr("Id");
+                return tr("ID");
 
             case 1:
                 return tr("Shortcut");

--- a/config/translations/lxqt-config-globalkeyshortcuts.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_ar.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_ar.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>المعرّف</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_arn.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_arn.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_ast.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_ast.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="141"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_bg.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_bg.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_ca.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_ca.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_cs.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_cs.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>Identif.</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_cy.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_cy.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation></translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_da.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_da.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_de.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_de.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>Kennung</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_el.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_el.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>Αναγνωριστικό</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_en_GB.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_en_GB.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_eo.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_eo.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_es.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_es.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>Identificador</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_es_VE.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_es_VE.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_et.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_et.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>Tunnus</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_eu.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_eu.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>id</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_fi.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_fi.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_fr.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_fr.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_gl.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_gl.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_he.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_he.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>מזהה</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_hr.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_hr.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_hu.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_hu.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>Azonosító</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_id.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_id.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_it.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_it.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_ja.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_ja.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_ka.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_ka.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_kab.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_kab.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_ko.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_ko.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_lg.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_lg.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>Endagamapeesa</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_lt.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_lt.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_lv.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_lv.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>Identifikators</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_nb_NO.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_nb_NO.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation></translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_nl.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_nl.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_oc.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_oc.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_pl.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_pl.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_pt.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_pt.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_pt_BR.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_pt_BR.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_ro_RO.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_ro_RO.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>Identificare</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_ru.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_ru.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ИД</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_si.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_si.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_sk_SK.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_sk_SK.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_sl.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_sl.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_sv.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_sv.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_th_TH.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_th_TH.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_tr.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_tr.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_uk.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_uk.ts
@@ -20,8 +20,8 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
-        <translation>Id</translation>
+        <source>ID</source>
+        <translation>ID</translation>
     </message>
     <message>
         <location filename="../default_model.cpp" line="146"/>

--- a/config/translations/lxqt-config-globalkeyshortcuts_zh_CN.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_zh_CN.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>

--- a/config/translations/lxqt-config-globalkeyshortcuts_zh_TW.ts
+++ b/config/translations/lxqt-config-globalkeyshortcuts_zh_TW.ts
@@ -20,7 +20,7 @@
     </message>
     <message>
         <location filename="../default_model.cpp" line="143"/>
-        <source>Id</source>
+        <source>ID</source>
         <translation>ID</translation>
     </message>
     <message>


### PR DESCRIPTION
"Id" in English refers to a concept in psychology not "identifier", although it's usually understood as "ID".