### PR TITLE
update fsf address

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -2,7 +2,7 @@
                        Version 2.1, February 1999
 
  Copyright (C) 1991, 1999 Free Software Foundation, Inc.
- 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+ <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/client/action.h
+++ b/client/action.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/client/client.h
+++ b/client/client.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/client/lxqt-globalkeys.h
+++ b/client/lxqt-globalkeys.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/config/shortcut_selector.h
+++ b/config/shortcut_selector.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 

--- a/ui/shortcut_selector.h
+++ b/ui/shortcut_selector.h
@@ -19,9 +19,8 @@
  * Lesser General Public License for more details.
 
  * You should have received a copy of the GNU Lesser General
- * Public License along with this library; if not, write to the
- * Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
- * Boston, MA 02110-1301 USA
+ * Public License along with this library; if not, see
+ * <https://www.gnu.org/licenses/>.
  *
  * END_COMMON_COPYRIGHT_HEADER */
 


### PR DESCRIPTION
See https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html for the most current published address

On rpm based systems, when building, the old fsf address throws an Error in rpmlint.

This PR doesn't change any functionality, it's completely administrative.